### PR TITLE
Release/0.8.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+Version 0.8.4 (2022-04-20)
+--------------------------
+Bump postgresql driver to 42.3.4 (#101)
+Bump slf4j-simple to 1.7.36 (#100)
+Bump swagger-ui to 4.10.3 (#99)
+Bump http4s to 0.21.33 (#97)
+Bump doobie to 0.13.4 (#98)
+Bump jackson-databind to 2.12.6.1 (#96)
+Disallow credentials in CORS requests (#103)
+
 Version 0.8.3 (2022-04-13)
 --------------------------
 Allow setup to be executed multiple times without failure (#94)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       POSTGRES_PASSWORD: ${IGLU_DB_PASSWORD:-iglusecret}
   iglu-server:
     container_name: iglu-server
-    image: snowplow/iglu-server:${IGLU_VERSION:-0.8.3}
+    image: snowplow/iglu-server:${IGLU_VERSION:-0.8.4}
     command: --config /snowplow/config/config.hocon
     environment:
       IGLU_SUPER_API_KEY: ${IGLU_SUPER_API_KEY:-5fb4713d-73ad-4163-93a9-2b82f0177c5b}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
     val CirceFs2   = "0.13.0"
     val Refined    = "0.9.24"
     val PureConfig = "0.15.0"
-    val SwaggerUi  = "4.2.1"
+    val SwaggerUi  = "4.10.3"
     val Slf4j      = "1.7.30"
     val ScalaCache = "0.28.0"
     val Postgresql = "42.2.25"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     val SwaggerUi  = "4.10.3"
     val Slf4j      = "1.7.36"
     val ScalaCache = "0.28.0"
-    val Postgresql = "42.2.25"
+    val Postgresql = "42.3.4"
     val Jackson    = "2.12.6.1"
 
     val Specs2     = "4.5.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val SchemaDdl  = "0.14.4"
     val IgluClient = "1.1.1"
 
-    val Http4s     = "0.21.22"
+    val Http4s     = "0.21.33"
     val Rho        = "0.21.0"
     val Doobie     = "0.13.4"
     val Decline    = "1.4.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
     val Slf4j      = "1.7.30"
     val ScalaCache = "0.28.0"
     val Postgresql = "42.2.25"
+    val Jackson    = "2.12.6.1"
 
     val Specs2     = "4.5.1"
     val Logback    = "1.2.3"
@@ -66,9 +67,11 @@ object Dependencies {
     "com.github.cb372"      %% "scalacache-cats-effect" % V.ScalaCache,
     "com.github.cb372"      %% "scalacache-caffeine"    % V.ScalaCache,
 
-    "org.webjars"           %  "swagger-ui"            % V.SwaggerUi,
-    "org.slf4j"             %  "slf4j-simple"          % V.Slf4j,
-    "org.postgresql"        %  "postgresql"            % V.Postgresql,
+    "org.webjars"                % "swagger-ui"        % V.SwaggerUi,
+    "org.slf4j"                  % "slf4j-simple"      % V.Slf4j,
+    "org.postgresql"             % "postgresql"        % V.Postgresql,
+    "com.fasterxml.jackson.core" % "jackson-databind"  % V.Jackson, // override transitive version to address security vulnerabilities
+
     "org.tpolecat"          %% "doobie-specs2"         % V.Doobie     % Test,
     "org.specs2"            %% "specs2-core"           % V.Specs2     % Test,
     "org.specs2"            %% "specs2-cats"           % V.Specs2     % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
     val Refined    = "0.9.24"
     val PureConfig = "0.15.0"
     val SwaggerUi  = "4.10.3"
-    val Slf4j      = "1.7.30"
+    val Slf4j      = "1.7.36"
     val ScalaCache = "0.28.0"
     val Postgresql = "42.2.25"
     val Jackson    = "2.12.6.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
 
     val Http4s     = "0.21.22"
     val Rho        = "0.21.0"
-    val Doobie     = "0.13.2"
+    val Doobie     = "0.13.4"
     val Decline    = "1.4.0"
     val Log4Cats   = "1.3.0"
     val Circe      = "0.14.1"

--- a/src/main/scala/com/snowplowanalytics/iglu/server/Server.scala
+++ b/src/main/scala/com/snowplowanalytics/iglu/server/Server.scala
@@ -139,7 +139,7 @@ object Server {
       anyMethod = false,
       allowedMethods = Some(Set("GET", "POST", "PUT", "OPTIONS", "DELETE")),
       allowedHeaders = Some(Set("content-type", "apikey")),
-      allowCredentials = true,
+      allowCredentials = false,
       maxAge = 1.day.toSeconds
     )
 


### PR DESCRIPTION
The purpose of this release is to bump dependencies, thereby removing potential security vulnerabilities.

Http4s has [deprecated the old way of configuring cors](https://github.com/http4s/http4s/security/advisories/GHSA-52cf-226f-rhr6); hence the change to `Server.scala`.